### PR TITLE
15 [common components]/loaders: replace loader component to circular/linear

### DIFF
--- a/src/components/loader.tsx
+++ b/src/components/loader.tsx
@@ -1,12 +1,37 @@
-import { CircularProgress, CircularProgressProps } from '@mui/material';
-import React, { ReactElement } from 'react';
+import React, { FunctionComponent, ReactElement } from 'react';
 
-export type LoaderProps = CircularProgressProps & {
+import {
+  CircularProgress,
+  CircularProgressProps,
+  LinearProgress,
+  LinearProgressProps,
+} from '@mui/material';
+
+export type LoaderProps = {
   shouldDisplayLoader: boolean;
 };
 
-export const Loader = ({
+export type CircularLoaderProps = LoaderProps & CircularProgressProps;
+export type LinearLoaderProps = LoaderProps & LinearProgressProps;
+
+export type MUILoadersProps = CircularLoaderProps | LinearProgressProps;
+
+function renderLoader<T extends MUILoadersProps>(
+  shouldRenderLoader: boolean,
+  Component: FunctionComponent<T>,
+  props: T
+): ReactElement | null {
+  return shouldRenderLoader ? <Component {...props} /> : null;
+}
+
+export const CircularLoader = ({
   shouldDisplayLoader,
   ...props
-}: LoaderProps): ReactElement | null =>
-  shouldDisplayLoader ? <CircularProgress {...props} /> : null;
+}: CircularLoaderProps): ReactElement | null =>
+  renderLoader(shouldDisplayLoader, CircularProgress, props);
+
+export const LinearLoader = ({
+  shouldDisplayLoader,
+  ...props
+}: LinearLoaderProps): ReactElement | null =>
+  renderLoader(shouldDisplayLoader, LinearProgress, props);


### PR DESCRIPTION
<!-- If your pull request closes an issue, replace the # with the issue number -->

#### Issue related
- Closes #15 
- Comment:  https://github.com/game1n/t8-cms/pull/19#issuecomment-1265899811 

#### What is being changed?
- replace Loader component to two `LinearLoader` and `CircularLoader`

####  Evidences
![15_circular_linear_loaders](https://user-images.githubusercontent.com/15786916/193811872-fa76cdb2-3799-4cd3-a6ca-e810c1972322.gif)

#### Observations

Linear component will be hidden if it's parent has not defined `width` property so the usage will be the same as provided by MUI (https://mui.com/material-ui/react-progress/#linear)
```
// percentages are for example
<Box sx={{ width: '100%' }}>
  <LinearLoader shouldDisplayLoader={true} />
</Box>

// or
<LinearLoader shouldDisplayLoader={true} sx={{ width: '100%' }} />
```